### PR TITLE
refactor(stm32): simplify CMSIS building and improve CPM integration

### DIFF
--- a/silicon/STMicroelectronics/stm32cubexx.CMakeLists.cmake
+++ b/silicon/STMicroelectronics/stm32cubexx.CMakeLists.cmake
@@ -74,8 +74,13 @@ file (GLOB STLegacyHeaders ${st_HAL_DRV_INCLUDE_LEGACY_DIR}/*.h)
 # glob all hal and ll headers
 file (GLOB HALAndLLHeaders ${st_HAL_DRV_INCLUDE_DIR}/*.h)
 
-set (AllHeaders ${STLegacyHeaders} ${cmsis_DEVICE_HEADERS} ${HALAndLLHeaders}
-                $<IF:$<BOOL:${cmsis}>,,${cmsis_CORE_HEADERS}> $<IF:$<BOOL:${cmsis}>,,${cmsis_INCLUDE_HEADERS}>)
+# Conditionally add CMSIS headers based on cmsis variable
+if (cmsis STREQUAL "")
+  set (AllHeaders ${STLegacyHeaders} ${cmsis_DEVICE_HEADERS} ${HALAndLLHeaders} ${cmsis_CORE_HEADERS}
+                  ${cmsis_INCLUDE_HEADERS})
+else ()
+  set (AllHeaders ${STLegacyHeaders} ${cmsis_DEVICE_HEADERS} ${HALAndLLHeaders})
+endif ()
 
 list (FILTER AllHeaders EXCLUDE REGEX "template")
 
@@ -103,7 +108,10 @@ set_target_properties (
              PUBLIC_HEADER "${${libName}_PUBLIC_HEADERS}"
              EXPORT_NAME framework)
 
-target_link_libraries (${libName} $<IF:$<BOOL:${cmsis}>,${cmsis},>)
+# Conditionally link CMSIS library
+if (NOT cmsis STREQUAL "")
+  target_link_libraries (${libName} ${cmsis})
+endif ()
 
 # set the target compile options
 settargetcompileoptions (libName)

--- a/silicon/STMicroelectronics/stm32cubexx.cmake
+++ b/silicon/STMicroelectronics/stm32cubexx.cmake
@@ -72,10 +72,15 @@ else ()
   cpmaddpackage (
     NAME
     ${libName}
-    GITHUB_REPOSITORY
-    https://github.com/STMicroelectronics/${STM32CubeXX}
+    GIT_REPOSITORY
+    https://github.com/STMicroelectronics/${STM32CubeXX}.git
     GIT_TAG
     ${GITHUB_BRANCH_${libName}}
+    GIT_SHALLOW
+    TRUE
+    GIT_SUBMODULES_RECURSE
+    TRUE
+    OPTIONS
     DOWNLOAD_ONLY
     TRUE)
   message (STATUS "${libName}: configuring and building from source")

--- a/silicon/STMicroelectronics/stm32cubexx.config.cmake
+++ b/silicon/STMicroelectronics/stm32cubexx.config.cmake
@@ -1,0 +1,1 @@
+include (${CMAKE_CURRENT_LIST_DIR}/cubemxTargets.cmake)


### PR DESCRIPTION
- Replace complex generator expressions with cleaner conditional logic
- Improve CMSIS header handling by using explicit if/else blocks instead of $<IF:...>
- Simplify target_link_libraries call with direct conditional linking
- Modernize CPMAddPackage syntax to use proper GIT_REPOSITORY parameter
- Add GIT_SHALLOW and GIT_SUBMODULES_RECURSE for faster cloning
- Add stm32cubexx.config.cmake template file for target configuration

Changes improve code readability and maintainability while ensuring proper CMSIS library integration based on external/internal detection. Aligns with "simplify-building-with-cmsis" branch objectives.

Files modified:
- silicon/STMicroelectronics/stm32cubexx.cmake
- silicon/STMicroelectronics/stm32cubexx.CMakeLists.cmake
- silicon/STMicroelectronics/stm32cubexx.config.cmake (new)