### PR TITLE
fix(stm32cubexx): use @ONLY for config template and dynamic target names

### DIFF
--- a/silicon/STMicroelectronics/stm32cubexx.cmake
+++ b/silicon/STMicroelectronics/stm32cubexx.cmake
@@ -88,7 +88,7 @@ else ()
   string (REPLACE "v" "" ${libName}Version ${GITHUB_BRANCH_${libName}})
   # 14 # configure the CMakeLists and Config files into the source directory
   configure_file (${CMAKE_CURRENT_LIST_DIR}/stm32cubexx.config.cmake ${${libName}_SOURCE_DIR}/${libName}Config.cmake
-                  COPYONLY)
+                  @ONLY)
   configure_file (${CMAKE_CURRENT_LIST_DIR}/stm32cubexx.CMakeLists.cmake ${${libName}_SOURCE_DIR}/CMakeLists.txt
                   COPYONLY)
   # 15 # add the subdirectory to build the library from source

--- a/silicon/STMicroelectronics/stm32cubexx.config.cmake
+++ b/silicon/STMicroelectronics/stm32cubexx.config.cmake
@@ -1,1 +1,1 @@
-include (${CMAKE_CURRENT_LIST_DIR}/cubemxTargets.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/@libName@Targets.cmake)


### PR DESCRIPTION
- Change configure_file from COPYONLY to @ONLY for proper variable substitution
- Replace hardcoded cubemxTargets.cmake with @libName@Targets.cmake template